### PR TITLE
Tweak some ux and style

### DIFF
--- a/src/Choose.tsx
+++ b/src/Choose.tsx
@@ -9,13 +9,24 @@ export default function Choose() {
   const [selection, setSelection] = useState<GameOption | undefined>();
 
   return (
-    <div className='choose-page'>
+    <div className='choose-page' style={{ WebkitTapHighlightColor: 'transparent' }}>
       <Choice selection={selection} setSelection={setSelection} type='rock' />
       <Choice selection={selection} setSelection={setSelection} type='paper' />
       <Choice selection={selection} setSelection={setSelection} type='scissors' />
       <Choice selection={selection} setSelection={setSelection} type='lizard' />
       <Choice selection={selection} setSelection={setSelection} type='spock' />
       <div style={{ marginBottom: '3em' }}>
+        {selection !== undefined && <>
+          <button
+            className='secondary'
+            onClick={() => setSelection(undefined)}
+            style={{
+              width: '100%',
+              lineHeight: '1.1em',
+              marginBottom: '1em',
+            }}
+          >Back to Selection</button>
+        </>}
         <button
           disabled={selection === undefined}
           style={{ width: '100%', lineHeight: '1.1em' }}
@@ -46,6 +57,10 @@ function Choice({ selection, setSelection, type }: {
   setSelection: (selection: GameOption | undefined) => void;
   type: GameOption;
 }) {
+  if (selection !== undefined && selection !== type) {
+    return <></>;
+  }
+
   return (
     <div
       className={`choice ${selection === type && 'selected'} ${type}`}

--- a/src/Result.tsx
+++ b/src/Result.tsx
@@ -39,15 +39,15 @@ export default function Result() {
 
   return (
     <div className='result'>
-      <center style={{ fontSize: 'calc(0.4 * var(--aw))' }}>{capitalize(result ?? '')}</center>
-      <div style={{ display: 'flex', placeContent: 'center' }}>
+      <center style={{ fontSize: 'calc(0.3 * var(--aw))' }}>{capitalize(result ?? '')}</center>
+      <div style={{ display: 'flex', placeContent: 'center', fontSize: '2em' }}>
         <table>
           <tr>
-            <td style={{ width: '10ch' }}>You:</td>
+            <td style={{ width: '6ch' }}>You:</td>
             <td>{getEmoji(choice ?? '')}</td>
           </tr>
           <tr>
-            <td style={{ width: '10ch' }}>Opponent:</td>
+            <td style={{ width: '6ch' }}>Them:</td>
             <td>{opponentOptions.split(', ').map(getEmoji).join(' or ')}</td>
           </tr>
         </table>

--- a/src/index.css
+++ b/src/index.css
@@ -78,6 +78,10 @@ button {
   color: white;
 }
 
+button.secondary {
+  background-color: #9291be;
+}
+
 button:disabled {
   opacity: 0.5;
   cursor: default;

--- a/src/index.css
+++ b/src/index.css
@@ -16,12 +16,14 @@ html {
 body {
   display: flex;
   font-size: 18px;
-  min-height: -webkit-fill-available;
+  height: var(--vh);
   overflow-x: hidden;
   overflow-y: auto;
 }
 
 :root {
+  --vh: 100vh;
+
   font-family: Helvetica;
   line-height: 1.5;
   font-weight: 400;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,3 +17,13 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     </Ctx.Provider>
   </React.StrictMode>,
 );
+
+const setVh = () => {
+  document.documentElement.style.setProperty(
+    '--vh',
+    `${window.innerHeight}px`,
+  );
+};
+
+setVh();
+window.addEventListener('resize', setVh);


### PR DESCRIPTION
- The selection screen is 2-step: choose then confirm. I've noticed some users miss this because they need to scroll down to see the confirm button and sometimes they don't realise. This fixes that by hiding the other options when a selection is active, and also adds a back button. (The back button is a bit unnecessary since you can also deselect your option, but that's not super clear either.)
- Makes the emojis bigger on the result screen. Also makes the main text a little smaller since `Lose` was not fitting on-screen on mobile (also overflowed and so didn't center correctly).
- Uses the actual height of the viewport to prevent phantom scroll behavior even when the content fits on screen. (This has to do with the auto-hiding behavior for the URL bar, which I think feels janky on single page apps.)