### PR TITLE
Add new config options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "react-copy-to-clipboard": "^5.1.0",
         "react-dom": "^18.2.0",
         "react-icons": "^5.2.0",
-        "rtc-pair-socket": "^0.1.5",
+        "rtc-pair-socket": "^0.1.6",
         "summon-ts": "^0.2.1",
         "typed-emitter": "^2.1.0",
         "zod": "^3.23.5"
@@ -547,6 +547,7 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.8.0.tgz",
       "integrity": "sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==",
+      "license": "ISC",
       "engines": {
         "node": ">= 10"
       }
@@ -1082,7 +1083,8 @@
     "node_modules/@types/aes-js": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/aes-js/-/aes-js-3.1.4.tgz",
-      "integrity": "sha512-v3D66IptpUqh+pHKVNRxY8yvp2ESSZXe0rTzsGdzUhEwag7ljVfgCllkWv2YgiYXDhWFBrEywll4A5JToyTNFA=="
+      "integrity": "sha512-v3D66IptpUqh+pHKVNRxY8yvp2ESSZXe0rTzsGdzUhEwag7ljVfgCllkWv2YgiYXDhWFBrEywll4A5JToyTNFA==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.5",
@@ -1410,7 +1412,8 @@
     "node_modules/aes-js": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
-      "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ=="
+      "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==",
+      "license": "MIT"
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -1976,7 +1979,8 @@
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -2722,6 +2726,7 @@
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/peerjs/-/peerjs-1.5.4.tgz",
       "integrity": "sha512-yFsoLMnurJKlQbx6kVSBpOp+AlNldY1JQS2BrSsHLKCZnq6t7saHleuHM5svuLNbQkUJXHLF3sKOJB1K0xulOw==",
+      "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^2.8.0",
         "eventemitter3": "^4.0.7",
@@ -2740,6 +2745,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/peerjs-js-binarypack/-/peerjs-js-binarypack-2.1.0.tgz",
       "integrity": "sha512-YIwCC+pTzp3Bi8jPI9UFKO0t0SLo6xALnHkiNt/iUFmUUZG0fEEmEyFKvjsDKweiFitzHRyhuh6NvyJZ4nNxMg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
       },
@@ -2981,9 +2987,10 @@
       }
     },
     "node_modules/rtc-pair-socket": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/rtc-pair-socket/-/rtc-pair-socket-0.1.5.tgz",
-      "integrity": "sha512-/zY+hjp+cz+dOFeoiCnTXs7vFcvV+rHLHD3iRJN7sN83Hea5BrgV5Zcse9rBm0jOypC3la9hPDzDxH0DcIxzDA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/rtc-pair-socket/-/rtc-pair-socket-0.1.6.tgz",
+      "integrity": "sha512-OKHMhnEl9QyIM6aVIQu71jZfFZZ8shnGEDIgLmrOO6FOKeeShDNY/3JqziHmC2Pbj6ba+rSrEjtbV/W7nhizyA==",
+      "license": "MIT",
       "dependencies": {
         "@types/aes-js": "^3.1.4",
         "aes-js": "^3.1.2",
@@ -2997,14 +3004,16 @@
       }
     },
     "node_modules/rtc-pair-socket/node_modules/base-x": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.0.tgz",
-      "integrity": "sha512-sMW3VGSX1QWVFA6l8U62MLKz29rRfpTlYdCqLdpLo1/Yd4zZwSbnUaDfciIAowAqvq7YFnWq9hrhdg1KYgc1lQ=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+      "license": "MIT"
     },
     "node_modules/rtc-pair-socket/node_modules/bs58": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
       "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "license": "MIT",
       "dependencies": {
         "base-x": "^5.0.0"
       }
@@ -3071,7 +3080,8 @@
     "node_modules/sdp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.0.tgz",
-      "integrity": "sha512-d7wDPgDV3DDiqulJjKiV2865wKsJ34YI+NDREbm+FySq6WuKOikwyNQcm+doLAZ1O6ltdO0SeKle2xMpN3Brgw=="
+      "integrity": "sha512-d7wDPgDV3DDiqulJjKiV2865wKsJ34YI+NDREbm+FySq6WuKOikwyNQcm+doLAZ1O6ltdO0SeKle2xMpN3Brgw==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.6.0",
@@ -3356,6 +3366,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.1.tgz",
       "integrity": "sha512-1AQO+d4ElfVSXyzNVTOewgGT/tAomwwztX/6e3totvyyzXPvXIIuUUjAmyZGbKBKbZOXauuJooZm3g6IuFuiNQ==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "sdp": "^3.2.0"
       },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^18.2.0",
     "react-icons": "^5.2.0",
-    "rtc-pair-socket": "^0.1.5",
+    "rtc-pair-socket": "^0.1.6",
     "summon-ts": "^0.2.1",
     "typed-emitter": "^2.1.0",
     "zod": "^3.23.5"

--- a/src/Ctx.ts
+++ b/src/Ctx.ts
@@ -22,6 +22,16 @@ type PageKind =
 
 export type GameOption = 'rock' | 'paper' | 'scissors' | 'lizard' | 'spock';
 
+const rtcConfig = (() => {
+  const envVar = import.meta.env.VITE_RTC_CONFIGURATION;
+
+  if (!envVar) {
+    return undefined;
+  }
+
+  return JSON.parse(envVar);
+})();
+
 export default class Ctx extends Emitter<{ ready(choice: GameOption): void }> {
   page = new UsableField<PageKind>('Home');
   mode: 'Host' | 'Join' = 'Host';
@@ -51,6 +61,7 @@ export default class Ctx extends Emitter<{ ready(choice: GameOption): void }> {
     const socket = new RtcPairSocket(
       this.key.value.base58(),
       this.mode === 'Host' ? 'alice' : 'bob',
+      rtcConfig,
     );
 
     this.socket.set(socket);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,6 @@ import react from '@vitejs/plugin-react-swc';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: '/mpc-lizard-spock/',
+  base: process.env.VITE_MPC_LIZARD_SPOCK_BASE ?? '/mpc-lizard-spock/',
   plugins: [react()],
 });


### PR DESCRIPTION
## What is this PR doing?

Adds two environment variables for configuration:
- `VITE_MPC_LIZARD_SPOCK_BASE`: for overriding the `/mpc-lizard-spock/` base url parameter for vite
- `VITE_RTC_CONFIGURATION`: for specifying the rtc config when using RtcPairSocket, in particular, to enable a turn server fallback for reliability

## How can these changes be manually tested?

Try setting these options and ensure they work as described.

## Does this PR resolve or contribute to any issues?

Contributes to: https://www.notion.so/pse-team/WebSocket-or-turn-fallback-for-browser-browser-demos-1acd57e8dd7e80608c0ce27d4c4b7ecb?pvs=4

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
